### PR TITLE
changed the computer of l&r wheel speeds

### DIFF
--- a/include/isc_roboteq/isc_roboteq.hpp
+++ b/include/isc_roboteq/isc_roboteq.hpp
@@ -27,6 +27,7 @@ private:
   // class atributes
   double leftspeed;
   double rightspeed;
+  double speed_multipler;
   bool roboteqIsConnected;
   double Max_Current;
   unsigned long Baudrate;

--- a/include/isc_roboteq/isc_roboteq.hpp
+++ b/include/isc_roboteq/isc_roboteq.hpp
@@ -27,10 +27,6 @@ private:
   // class atributes
   double leftspeed;
   double rightspeed;
-  double lwr;
-  double rwr;
-  double ws; 
-  float speedMultipler;
   bool roboteqIsConnected;
   double Max_Current;
   unsigned long Baudrate;

--- a/src/isc_roboteq.cpp
+++ b/src/isc_roboteq.cpp
@@ -23,7 +23,6 @@ Roboteq::Roboteq(rclcpp::NodeOptions options)
 : Node("roboteq", options)
 {
   Max_Current = this->declare_parameter("Max_Current", 40.0);
-  USB_Port = this->declare_parameter("USB_Port", " ");   
   Baudrate = this->declare_parameter("Baudrate", 9600);
   ChunkSize = this->declare_parameter("ChunkSize", 64);
   
@@ -108,9 +107,9 @@ unsigned char Roboteq::constrainSpeed(double speed)
 // called every time it recives a Twist message
 void Roboteq::driveCallBack(const geometry_msgs::msg::Twist::SharedPtr msg)
 {
-	speed_multipler = 60.0;
-  rightspeed = (msg->linear.x - msg->angular.z) * speed_multipler;
-  leftspeed = (msg->linear.x + msg->angular.z) * speed_multipler;
+  speed_multipler = 60.0;
+  leftspeed = (msg->linear.x - msg->angular.z) * speed_multipler;
+  rightspeed = (msg->linear.x + msg->angular.z) * speed_multipler;
   move();
   RCLCPP_INFO(this->get_logger(), "Roboteq: %s%lf%s%lf"," Left Wheel = ", leftspeed, " Right Wheel = ", rightspeed);
 }
@@ -151,7 +150,7 @@ inline bool isPlusOrMinus(const string &token)
 }
 
 // send command to controller over serial
-// and listen to controller for response
+// and listen to Roboteq for response
 bool Roboteq::send_Command(std::string command)
 {
   BufferedFilterPtr echoFilter = serialListener.createBufferedFilter(SerialListener::exactly(command));
@@ -163,8 +162,7 @@ bool Roboteq::send_Command(std::string command)
 
 	BufferedFilterPtr plusMinusFilter = serialListener.createBufferedFilter(isPlusOrMinus);
 	std::string result = plusMinusFilter->wait(100);
-	 // remove this friday after testing
-	RCLCPP_INFO(this->get_logger(), "%s%s","The Roboteq sent back a result of ", result);
+
 	if(result != "+"){
 		if(result == "-"){
 			RCLCPP_ERROR(this->get_logger(), "%s","The Roboteq rejected the command:(");

--- a/src/isc_roboteq.cpp
+++ b/src/isc_roboteq.cpp
@@ -108,11 +108,8 @@ unsigned char Roboteq::constrainSpeed(double speed)
 // called every time it recives a Twist message
 void Roboteq::driveCallBack(const geometry_msgs::msg::Twist::SharedPtr msg)
 {
-  speedMultipler = 127;
-  lwr =  rwr =  0.14;
-  ws = 0.6;
-  rightspeed = ((msg->linear.x - msg->angular.z) * ws / 2.0) / rwr;
-  leftspeed = ((msg->linear.x + msg->angular.z) * ws / 2.0) / lwr;
+  rightspeed = (msg->linear.x - msg->angular.z);
+  leftspeed = (msg->linear.x + msg->angular.z);
   move();
   RCLCPP_INFO(this->get_logger(), "Roboteq: %s%lf%s%lf"," Left Wheel = ", leftspeed, " Right Wheel = ", rightspeed);
 }
@@ -212,7 +209,7 @@ Roboteq::~Roboteq()
   roboteqIsConnected = false;
 	RCLCPP_INFO(this->get_logger(), "%s","Port Closed:)");
 }
-}
+} // end of namespace Roboteq
 
 int main(int argc, char * argv[])
 {

--- a/src/isc_roboteq.cpp
+++ b/src/isc_roboteq.cpp
@@ -108,8 +108,9 @@ unsigned char Roboteq::constrainSpeed(double speed)
 // called every time it recives a Twist message
 void Roboteq::driveCallBack(const geometry_msgs::msg::Twist::SharedPtr msg)
 {
-  rightspeed = (msg->linear.x - msg->angular.z);
-  leftspeed = (msg->linear.x + msg->angular.z);
+	speed_multipler = 60.0;
+  rightspeed = (msg->linear.x - msg->angular.z) * speed_multipler;
+  leftspeed = (msg->linear.x + msg->angular.z) * speed_multipler;
   move();
   RCLCPP_INFO(this->get_logger(), "Roboteq: %s%lf%s%lf"," Left Wheel = ", leftspeed, " Right Wheel = ", rightspeed);
 }


### PR DESCRIPTION
# Description
In regards to issue #8, the robot refuses to turn. This was because both left and right wheel speed calculations used the same formula when the should be different. I also found that the speed multiplier scaled the wheel speed to the point where it was above the 7F hex max value of the roboteq controller so the node always set the wheel speed to 127 or 7F. This caused an all or nothing movement of yeti and sent her flying a full speed across the room. For now I throttled down the speed multiplier to 60.0 because if I took it out completely, the node would be telling the roboteq controller to turn the motors at 1.6% when we want to turn the motors at 100%. So a value of 60.0 would scale the wheel speed to 94.5% if we ask the roboteq to turn the motors at 100%. this gives us a cushion of safety. Another thing changed is since It is the nodes responsibility now to search all of the open `/dev` ports and find which one the roboteq is opened, the ros parameter for the attribute `USB_port` is not needed anymore. 

Fixes # (issue)
#8 
All or nothing movement

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This has only been tested on my personal computer using a virtual serial port and mathematically, the speeds it is trying to send checks out but tomorrow I will test it on actual yeti. On the physical yeti, it works perfectly, left joy stick turns yeti left, right joy stick turns yeti right and the forwards/backwards joy stick drives yeti forwards and backwards.

# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules