### PR TITLE
changed regex pattern

### DIFF
--- a/include/isc_roboteq/isc_roboteq.hpp
+++ b/include/isc_roboteq/isc_roboteq.hpp
@@ -34,12 +34,13 @@ private:
   std::string usb_port;
   unsigned long baud;
   int chunk_size;
+  bool flip_inputs = false;
 
   // class methods
   void driveCallBack(const geometry_msgs::msg::Twist::SharedPtr msg);
   void enumerate_port();
   void connect();
-  unsigned char constrainSpeed(double speed);
+  int constrainSpeed(double speed);
   bool send_Command(string command);
   void move();
   void set_current();

--- a/src/isc_roboteq.cpp
+++ b/src/isc_roboteq.cpp
@@ -43,7 +43,7 @@ the roboteqs /dev path to the usb_port attribute
 */
 void Roboteq::enumerate_port()
 {
-  std::regex manufacture("(Prolific)(.*)");
+  std::regex manufacture("(Prolific | Roboteq)(.*)");
   std::vector<serial::PortInfo> devices = serial::list_ports();
   std::vector<serial::PortInfo>::iterator ports = devices.begin();
   while(ports != devices.end())

--- a/src/isc_roboteq.cpp
+++ b/src/isc_roboteq.cpp
@@ -102,14 +102,17 @@ void Roboteq::connect()
 }
 
 // put a speed govenor on how fast the motors can turn
-unsigned char Roboteq::constrainSpeed(double speed)
+int Roboteq::constrainSpeed(double speed)
 {
-  unsigned char temp_speed = fabs(speed);
-    if(temp_speed > 127)
-    {
-        temp_speed = 127;
-    }
-  return temp_speed;
+	if(abs(speed) > 1000){
+		if(speed > 0){
+			speed = 1000;
+	}
+	else{
+		speed = -1000;
+	}		
+	}
+	return speed;
 }
 
 /* 
@@ -211,18 +214,8 @@ void Roboteq::move()
     RCLCPP_ERROR(this->get_logger(), "%s","The Roboteq needs to connected first:(");
     return;
   }
-  if(right_speed < 0){
-    send_Command(stringFormat("!a%.2X", constrainSpeed(right_speed)));
-  }
-  else{
-    send_Command(stringFormat("!A%.2X", constrainSpeed(right_speed)));
-  }
-  if(left_speed < 0){
-    send_Command(stringFormat("!b%.2X", constrainSpeed(left_speed)));
-  }
-  else{
-    send_Command(stringFormat("!B%.2X", constrainSpeed(left_speed)));
-  }
+	send_Command(stringFormat("!G 1 %d", (flip_inputs ? -1 : 1) * constrainSpeed(right_speed)));
+	send_Command(stringFormat("!G 2 %d", (flip_inputs ? -1 : 1) * constrainSpeed(left_speed)));
 }
 
 // Disconnect the controller from serial 


### PR DESCRIPTION
during testing, ohms roboteq had a different manufacture assigned to it so the node couldn't find it. so the node now searches for either ohms controller or yetis controller 